### PR TITLE
Use dynamic file upload paths

### DIFF
--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -5,6 +5,8 @@ use \WP_CLI;
 
 class Import_Twitter_Command {
 
+	private string $data_dir = '';
+
 	private int $tweets_processed = 0;
 	private int $tweets_skipped = 0;
 
@@ -44,6 +46,7 @@ class Import_Twitter_Command {
 			return;
 		}
 
+		$this->data_dir = (wp_upload_dir())['basedir'] . '/twitter-archive';
 		$files = $this->get_multipart_tweet_archive_filenames();
 
 		foreach($files as $filename) {
@@ -144,8 +147,8 @@ class Import_Twitter_Command {
 	 * @return array
 	 */
 	private function get_multipart_tweet_archive_filenames() : array {
-		$files[] = ABSPATH . 'wp-content/uploads/twitter-archive/tweets.js';
-		$additional_parts = glob(ABSPATH . 'wp-content/uploads/twitter-archive/tweets-part*.js');
+		$files[] = $this->data_dir . '/tweets.js';
+		$additional_parts = glob($this->data_dir . '/tweets-part*.js');
 
 		$files = array_merge($files, $additional_parts);
 
@@ -216,7 +219,7 @@ class Import_Twitter_Command {
 	private function process_media(\stdClass $tweet, int $post_id): void
 	{
 		if ( count($this->media_files) === 0) {
-			$this->media_files = scandir(ABSPATH . 'wp-content/uploads/twitter-archive/tweets_media');
+			$this->media_files = scandir($this->data_dir . '/tweets_media');
 		}
 
 		if (isset($tweet->entities->media)) {


### PR DESCRIPTION
Didn't open an issue for this. Just found it while looking at some other things.

This PR changes the import to use `wp_upload_dir()` to fetch the correct uploads directory, instead of having it hard-coded.

Probably not needed for this kind of project, but best practice.

I have tested this with a default WordPress setup and that works. I've not tested with a moved `uploads` directory.