### PR TITLE
Use <a> tags for links in Tweets

### DIFF
--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -132,7 +132,6 @@ class Import_Twitter_Command {
 			'post_type' => 'birdsite_tweet',
 			'post_status' => 'publish',
 			'post_content' => $tweet_text,
-			//'post_content' => json_encode($tweet, JSON_THROW_ON_ERROR),
 			'post_date' => $created_at,
 			'post_date_gmt' => $created_at,
 		];

--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -121,7 +121,8 @@ class Import_Twitter_Command {
 
 		if (isset($tweet->entities->urls)) {
 			foreach($tweet->entities->urls as $url) {
-				$tweet_text = str_replace($url->url, $url->expanded_url, $tweet_text);
+				$link_tag = "<a href=\"{$url->expanded_url}\">{$url->display_url}</a>";
+				$tweet_text = str_replace($url->url, $link_tag, $tweet_text);
 			}
 		}
 
@@ -130,7 +131,7 @@ class Import_Twitter_Command {
 			'post_author' => $post_author,
 			'post_type' => 'birdsite_tweet',
 			'post_status' => 'publish',
-			'post_title' => $tweet_text,
+			'post_content' => $tweet_text,
 			//'post_content' => json_encode($tweet, JSON_THROW_ON_ERROR),
 			'post_date' => $created_at,
 			'post_date_gmt' => $created_at,

--- a/classes/tweet-post-type.php
+++ b/classes/tweet-post-type.php
@@ -67,7 +67,7 @@ class Tweet_Post_Type {
 	public function set_custom_columns(array $columns) : array
 	{
 		unset($columns['title']);
-		$columns['title'] = __( 'Tweet', 'birdsite_archive' );
+		$columns['tweet'] = __( 'Tweet', 'birdsite_archive' );
 		$columns['favorite_count'] = __( 'Likes', 'birdsite_archive' );
 		$columns['retweet_count'] = __( 'Retweets', 'birdsite_archive' );
 		$columns['has_media'] = __( 'Has Media', 'birdsite_archive' );
@@ -79,6 +79,9 @@ class Tweet_Post_Type {
 	public function populate_tweet_columns(string $column, int $post_id): void
 	{
 		switch ( $column ) {
+			case 'tweet':
+				echo get_post($post_id)->post_content;
+				break;
 			case 'retweet_count' :
 				echo get_post_meta($post_id, '_retweet_count', true);
 				break;

--- a/classes/tweet-post-type.php
+++ b/classes/tweet-post-type.php
@@ -80,7 +80,12 @@ class Tweet_Post_Type {
 	{
 		switch ( $column ) {
 			case 'tweet':
-				echo get_post($post_id)->post_content;
+				$tweet = get_post($post_id)->post_content;
+				// For compatibility with older imports that may have used the title for the Tweet
+				if (empty($tweet)) {
+					$tweet = get_the_title($post_id);
+				}
+				echo $tweet;
 				break;
 			case 'retweet_count' :
 				echo get_post_meta($post_id, '_retweet_count', true);


### PR DESCRIPTION
Resolves #7

This PR uses `<a>` tags for links that appear in Tweets. Because these aren't normally rendered in `post_title`s, I've also moved the Tweet content into `post_content`.

To make the plugin backwards compatible, the column displaying Tweets from older imports using the old method, the column code falls back to using the title if there is no content.

You MAY not want to merge this, which is fine. Or you may want to have using the `post_content` field as an option on the import. In which case let me know and I'll add that to the PR.

Thanks!