### PR TITLE
Save original Tweet URLs

### DIFF
--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -45,7 +45,6 @@ class Import_Twitter_Command {
 
 		if ($this->post_author_id === 0) {
 			WP_CLI::error('Error: invalid post author ID');
-			return;
 		}
 
 		$this->data_dir = (wp_upload_dir())['basedir'] . '/twitter-archive';

--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -214,6 +214,10 @@ class Import_Twitter_Command {
 		return $tweets;
 	}
 
+	private function make_tweet_url(\stdClass $tweet) : string {
+		return 'https://twitter.com/' . $this->account_data->username . '/status/' . $tweet->id;
+	}
+
 	private function set_postmeta(\stdClass $tweet, int $post_id) : void {
 		update_post_meta($post_id, '_retweet_count', $tweet->retweet_count );
 		update_post_meta($post_id, '_favorite_count', $tweet->favorite_count );
@@ -221,6 +225,9 @@ class Import_Twitter_Command {
 		if (isset($tweet->in_reply_to_status_id_str)) {
 			update_post_meta($post_id, '_in_reply_to_status_id_str', $tweet->in_reply_to_status_id_str );
 		}
+
+		// Tweets don't seem to have a Tweet URL in the data, so we need to make one.
+		update_post_meta($post_id, '_tweet_url', $this->make_tweet_url($tweet));
 	}
 
 	private function set_hashtags(\stdClass $tweet, int $post_id) {

--- a/readme.txt
+++ b/readme.txt
@@ -26,8 +26,9 @@ Your Twitter archive contains some data you might not want accessible by someone
 you've uploaded it your site.  It is highly recommended before uploading the data folder that
 you delete all files except for:
 
-* tweets.json
+* tweets.js
 * tweets_media/*
+* account.js
 
 This plugin doesn't need more than that at the moment.
 
@@ -36,7 +37,7 @@ This plugin doesn't need more than that at the moment.
 1. Install and Activate this plugin
 1. Unzip your Twitter Archive
 1. Copy the data/ folder from the Twitter archive to the wp-contents/uploads/twitter-archive folder. (read privacy note above)
-1. Run `wp import-twitter --author=<post_author>` where <post_author> is your WordPress User ID
+1. Run `wp import-twitter <post_author>` where <post_author> is your WordPress User ID
 
 == Starting Over ==
 


### PR DESCRIPTION
Well this was quite the minor rabbit-hole!

You can take or leave this. I wanted to save the original Tweet URLs. This doesn't fix an issue, but was something I wanted to do.

But the Tweet data doesn't include the URL!

So I decided to import the account data from the account.js in the Twitter export (a useful thing to do anyway?) and then construct the links before saving them.

Notes:
* This PR depends on #8 - if you don't want to merge #8 I can rework this PR.
* I fixed some errors in the `readme.txt` while I was at it. And removed one unreachable line of code that was bothering me. If you don't merge this you may want to apply those changes anyway.
* The readme change fixed a load of whitespace. Did you have weird line-endings?
* Arguably, it might be nice to store the entire Tweet JSON in post meta. Looks like you may have previously tried to do this but storing it in `post_content`. If you want a PR for this as well I'm happy to do that. But I like having the original URL separate.

