### PR TITLE
Rework of media importing to handle multiple images + video

### DIFF
--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -382,9 +382,9 @@ class Import_Twitter_Command {
 			foreach($tweet->extended_entities->media as $media) {
 				$media = apply_filters('birdsite_import_media', $media, $tweet);
 
-				if ($media->type === 'video') {
+				if ($this->media_is_video($media)) {
 					$media_id = $this->find_video_id_from_variants($media, $tweet_media_filenames);
-				} elseif ($media->type === 'photo') {
+				} elseif ($this->media_is_photo($media)) {
 					$media_id = array_slice(explode('/', $media->media_url), -1, 1)[0];
 				} else {
 					WP_CLI::warning('Unknown media type: ' . $media->type);
@@ -414,10 +414,10 @@ class Import_Twitter_Command {
                 $post->filter = true;
                 $media_url = esc_attr($this->base_upload_folder_url . "/twitter-archive/tweets_media/{$media_filename}");
 
-				if ($media->type === 'video') {
+				if ($this->media_is_video($media)) {
 					// Add to the Tweet video tags
 					$tweet_video_tags .= apply_filters('birdsite_import_video_tag', "<video controls><source src=\"$media_url\" /></video>", $media, $tweet);
-				} elseif ($media->type === 'photo') {
+				} elseif ($this->media_is_photo($media)) {
 					// Add to the Tweet img tags
 					$tweet_img_tags .= apply_filters('birdsite_import_img_tag', "<img src=\"$media_url\" />", $media, $tweet);
 				}
@@ -444,7 +444,7 @@ class Import_Twitter_Command {
 	 * Returns the media ID of the video file (the last part of the filename), or
 	 * an empty string if no match is found.
 	 *
-	 * @param  array $media
+	 * @param  object $media
 	 * @param  array $tweet_media_filenames
 	 * @return string
 	 */
@@ -465,6 +465,26 @@ class Import_Twitter_Command {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Returns true if the media object is a video.
+	 *
+	 * @param  object $media  A media object from the tweets.js format
+	 * @return bool
+	 */
+	private function media_is_video($media) {
+		return in_array( $media->type, ['video', 'animated_gif'] );
+	}
+
+	/**
+	 * Returns true if the media object is a photo.
+	 *
+	 * @param  object $media  A media object from the tweets.js format
+	 * @return bool
+	 */
+	private function media_is_photo($media) {
+		return in_array( $media->type, ['photo'] );
 	}
 
 	/**

--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -382,9 +382,9 @@ class Import_Twitter_Command {
 			foreach($tweet->extended_entities->media as $media) {
 				$media = apply_filters('birdsite_import_media', $media, $tweet);
 
-				if ($media->type === 'video') {
+				if ($this->media_is_video($media)) {
 					$media_id = $this->find_video_id_from_variants($media, $tweet_media_filenames);
-				} elseif ($media->type === 'photo') {
+				} elseif ($this->media_is_photo($media)) {
 					$media_id = array_slice(explode('/', $media->media_url), -1, 1)[0];
 				} else {
 					WP_CLI::warning('Unknown media type: ' . $media->type);
@@ -414,10 +414,10 @@ class Import_Twitter_Command {
                 $post->filter = true;
                 $media_url = esc_attr($this->base_upload_folder_url . "/twitter-archive/tweets_media/{$media_filename}");
 
-				if ($media->type === 'video') {
+				if ($this->media_is_video($media)) {
 					// Add to the Tweet video tags
 					$tweet_video_tags .= apply_filters('birdsite_import_video_tag', "<video controls><source src=\"$media_url\" /></video>", $media, $tweet);
-				} elseif ($media->type === 'photo') {
+				} elseif ($this->media_is_photo($media)) {
 					// Add to the Tweet img tags
 					$tweet_img_tags .= apply_filters('birdsite_import_img_tag', "<img src=\"$media_url\" />", $media, $tweet);
 				}
@@ -444,7 +444,7 @@ class Import_Twitter_Command {
 	 * Returns the media ID of the video file (the last part of the filename), or
 	 * an empty string if no match is found.
 	 *
-	 * @param  array $media
+	 * @param  object $media
 	 * @param  array $tweet_media_filenames
 	 * @return string
 	 */
@@ -465,6 +465,26 @@ class Import_Twitter_Command {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Returns true if the media object is a video.
+	 *
+	 * @param  object $media  A media object from the tweets.js format
+	 * @return bool
+	 */
+	private function media_is_video($media) {
+		return in_array( ['video', 'animated_gif'], $media->type );
+	}
+
+	/**
+	 * Returns true if the media object is a photo.
+	 *
+	 * @param  object $media  A media object from the tweets.js format
+	 * @return bool
+	 */
+	private function media_is_photo($media) {
+		return in_array( ['photo'], $media->type );
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -63,7 +63,8 @@ This plugin doesn't need more than that at the moment.
 * birdsite_import_media -- A single media (video or image) being imported from the archive
 * birdsite_import_img_tag -- The <img> tag added the post_content to embed an image
 * birdsite_import_img_tags -- The collected <img> tags added the post_content to embed all images
-*
+* birdsite_import_video_tag -- The <video> tag added the post_content to embed a video
+* birdsite_import_video_tags -- The collected <video> tags added the post_content to embed all videos
 
 == Starting Over ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: twitter, archive, wp-cli, import
 Requires at least: 6.0.0
 Tested up to: 6.1
 Requires PHP: 7.4.0
-Stable tag: 2.0.3
+Stable tag: 2.0.4
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -83,9 +83,12 @@ Thank you to:
 
 * Jann Gobble (https://github.com/janngobble) for helping me test the multipart Twitter Archives
 * Alex Standiford (https://github.com/alexstandiford) and Tim Lyttle (https://github.com/timnolte) for a late night Zoom call and strategy session and this stuff.
-* Ross Wintle (https://github.com/rosswintle) for a large amount of the refactoring into the 2.0.0 release.
+* Ross Wintle (https://github.com/rosswintle) for a large amount of the refactoring into the 2.0.0 release and media import improvements.
 
 == Changelog ==
+
+= 2.0.4 =
+* Import multiple images and videos for a single tweet.
 
 = 2.0.3 =
 * Configured as a WP-CLI package

--- a/readme.txt
+++ b/readme.txt
@@ -61,7 +61,8 @@ This plugin doesn't need more than that at the moment.
 * birdsite_import_hashtags -- The list of hashtags to be imported for a single tweet
 * birdsite_import_ticker_symbols -- The list of hashtags to be imported for a single tweet
 * birdsite_import_media -- A single media (video or image) being imported from the archive
-* birdsite_import_img_tag -- The <img> tag added the post_content to embed image
+* birdsite_import_img_tag -- The <img> tag added the post_content to embed an image
+* birdsite_import_img_tags -- The collected <img> tags added the post_content to embed all images
 *
 
 == Starting Over ==

--- a/twitter-archive-to-wp.php
+++ b/twitter-archive-to-wp.php
@@ -7,7 +7,7 @@
  * Author URI:      https://shawnhooper.ca/
  * Text Domain:     birdsite-archive
  * Domain Path:     /languages
- * Version:         2.0.3
+ * Version:         2.0.4
  *
  * @package         Birdsite_Archive
  */


### PR DESCRIPTION
Resolves #17 

This is a fairly major refactor of media handling. It enables:
 - Import of mulitple media items for each tweet
 - Import of video media
 - Import of animated GIFs (Twitter converted these to mp4s!)

It saves multiple media items using meta keys:
 - `_tweet_media_x`
 - `_tweet_media_type_x`

All media are added to the Tweet using `img` or `video` tags.

I've tried to keep to the filtering conventions you have used.

It attempts some optimisation by only updating the post once when processing media for a post, and by changing how files are looped through. Specifically:

 - I now load the media file list on initialization
 - I index the media file list by the Tweet ID
 - I use the index to only loop through the media files for the current Tweet

I did not implement a `--import-media` flag - this can be done another time.

I bumped the version number and updated the readme.txt

This now VERY NEARLY successfully processes my entire Tweet history and media. There is one media not found error. I've not investigated this yet.

```
Success: Import Complete!
Success: 61439 tweets processed
Success: 7303 tweets skipped
Success: 2821 media found
Success: 1 media not found
Success: 0 media had an unknown type
```

I'll leave this with you for review. I shall attempt to provide a minimal subset of my import for testing purposes, if that's helpful? But it's too late to do that today.

Thanks! Hope you like the improvements!