### PR TITLE
A Litany of Potential Improvements.

### DIFF
--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -72,6 +72,7 @@ class Import_Twitter_Command {
 	public function __invoke($args, $assoc_args) : void {
 		$this->post_type = isset($assoc_args['post-type']) ? $assoc_args['post-type'] : 'birdsite_tweet';
 		$this->hashtag_taxonomy = isset($assoc_args['hashtag-taxonomy']) ? $assoc_args['hashtag-taxonomy'] : 'birdsite_hashtags';
+		$this->use_aside_format = isset($assoc_args['use-aside-format']);
 
 		if (! post_type_exists($this->post_type)) {
 			WP_CLI::error('Error: invalid post type.');
@@ -213,6 +214,9 @@ class Import_Twitter_Command {
 			$this->set_hashtags($tweet, $post_id);
 			$this->set_ticker_symbols($tweet, $post_id);
 			$this->process_media($tweet, $post_id);
+				if ($this->use_aside_format) {
+					set_post_format(get_post($post_id), 'aside');
+				}
 		}
 
 		do_action('birdsite_import_end_of_file', $filename);

--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -72,6 +72,11 @@ class Import_Twitter_Command {
 	public function __invoke($args, $assoc_args) : void {
 		$this->post_type = isset($assoc_args['post-type']) ? $assoc_args['post-type'] : 'birdsite_tweet';
 		$this->hashtag_taxonomy = isset($assoc_args['hashtag-taxonomy']) ? $assoc_args['hashtag-taxonomy'] : 'birdsite_hashtags';
+
+		if (! post_type_exists($this->post_type)) {
+			WP_CLI::error('Error: invalid post type.');
+		}
+
 		if (! taxonomy_exists($this->hashtag_taxonomy)) {
 			WP_CLI::error('Error: invalid taxonomy.');
 		}

--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -205,6 +205,12 @@ class Import_Twitter_Command {
 				continue;
 			}
 
+			if ($this->skip_replies && strpos(trim($tweet->full_text), '@') === 0) {
+				WP_CLI::success("Skipping Tweet as it starts with '@'");
+				$this->tweets_skipped++;
+				continue;
+			}
+
 			$tweet_text = $tweet->full_text;
 
 			if (isset($tweet->entities->urls)) {

--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -238,7 +238,8 @@ class Import_Twitter_Command {
 
 			$post_id = $this->process_tweet($tweet, $this->post_author_id);
 
-			$this->id_to_post_id_map[$tweet->id] = $post_id;
+			if($post_id) {
+				$this->id_to_post_id_map[$tweet->id] = $post_id;
 
 				if ($this->use_aside_format) {
 					set_post_format(get_post($post_id), 'aside');

--- a/classes/import-twitter-command.php
+++ b/classes/import-twitter-command.php
@@ -254,7 +254,7 @@ class Import_Twitter_Command {
 
 		do_action('birdsite_import_end_of_file', $filename);
 
-		WP_CLI::success('Import Complete - ' . $this->tweets_processed . ' tweets processed, ' . $this->tweets_skipped . 'skipped');
+		WP_CLI::success('Import Complete - ' . $this->tweets_processed . ' tweets processed, ' . $this->tweets_skipped . ' skipped');
 	}
 
 	private function is_quote_retweet(\stdClass $tweet) : bool {

--- a/readme.txt
+++ b/readme.txt
@@ -36,7 +36,7 @@ This plugin doesn't need more than that at the moment.
 
 1. Install and Activate this plugin
 1. Unzip your Twitter Archive
-1. Copy the data/ folder from the Twitter archive to the wp-contents/uploads/twitter-archive folder. (read privacy note above)
+1. Copy the data/ folder from the Twitter archive to the wp-content/uploads/twitter-archive folder. (read privacy note above)
 1. Run `wp import-twitter <post_author>` where <post_author> is your WordPress User ID
 
 == Actions ==

--- a/twitter-archive-to-wp.php
+++ b/twitter-archive-to-wp.php
@@ -17,9 +17,6 @@ namespace ShawnHooper\BirdSiteArchive;
 use WP_CLI;
 
 class BirdSiteArchive {
-
-	private ?bool $has_tweets = null;
-
 	/**
 	 * Hook this plugin into WordPress' actions & filters
 	 */
@@ -35,7 +32,6 @@ class BirdSiteArchive {
 		$tweet_post_type = new Tweet_Post_Type();
 		$tweet_post_type->wordpress_hooks();
 	}
-
 }
 
 $_GLOBALS['BirdSiteArchive'] = new BirdSiteArchive();


### PR DESCRIPTION
Hey Shawn!

Thanks _so_ much for putting this together. I ended up making several changes to get it to work in my specific use-case. I'm not convinced all of this needs to go in core, so I don't necessarily think this should be merged, I'm just creating this so that it provides a place to discuss details of what I did so that they can be extracted into something more atomic. Consider this a proof of concept, I suppose.

I tried to make the commits as atomic as I could, to make it read-able.

Here's the big things that I needed. Note that there's still some other commits below that are not in these details, but generally I think they're straightforward enough and explained in the commit well-enough to not need further information.

## Different Post Type And Taxonomy For Import

I didn't want to use the built-in post type. In my case, I wanted to merge this content in with my existing content that I have been publishing. This meant that I needed to have a way to override the post type that is used when creating the post. This was pretty straightforward - just needed to add a flag to the config, check that the type is valid, and use that instead of what's default.

## Specify A Since Date

I personally needed to specify a "since date" for my account. My personal usage of Twitter started using it as a promotional tool, and as a result when I was still learning to use it I had years of really spammy content back in the late '00s. (What do you want from me, it was normal and suggested at the time!)

Anyway, I basically decided everything after a specific date was just garbage and I didn't want it in my import.

So, to work around that, [I needed to set a since-date flag](https://github.com/shawnhooper/twitter-archive-to-wp/commit/5da91a0bd18e1ef65a34704d0877edefba1597b6), which allowed me to skip any content older than that date.

## Aside Format

My content is not organized into different CPTs. Instead, I'm using good ol' fashioned post formats. This is because I use the WordPress app to publish my content, and that app does not support custom post types but it does support post formats. So, [I needed to be able to import this content as an aside](https://github.com/shawnhooper/twitter-archive-to-wp/commit/87c5bd9b9205ed875d9fd408baf67a04ec282e11).

## Media Library Import And Block Creation

I think there was something in this about attaching media using post meta or something. I appreciate the structured approach, but it wasn't what I needed personally. Instead, I wanted the content to be added as either a video block, a gallery, or a single image. I also needed the content to be added to my media library, because other parts of my stack synchronize with the media library automatically.

So, I ended up rewriting this part so that it imports content in the media library (which creates the different image sizes, etc), and also appended the blocks to the existing content.

Sorry [I couldn't get this commit in a more atomic fashion](https://github.com/shawnhooper/twitter-archive-to-wp/commit/0a02d8b6998451a68cb19e6f1c006505480e9bd1), as I think that the block changes are separate from the media library changes.

## Tweet Merging

I didn't want my follow-up messages to be added as comments. Instead, I wanted them to be appended to the content as-if it were a single post. To do this, [I needed to merge the tweets together](https://github.com/shawnhooper/twitter-archive-to-wp/commit/e108caf209478e0041780487610babd426979704) and get rid of some extraneous stuff like the (1/2) and the (2/2) that Twitter automatically adds to tweets when making threads.

## Skip Retweets

I added a way to skip retweets. I didn't want this extra content to be archived on my site, since it wasn't written by me. Again, pretty straightforward for the most part - just added a flag, and some detection on the tweet like you've already done with skip replies.

## More Sensitive Skip Replies

A tweet can be a reply without technically being a reply. This happens when you compose a tweet, and when composing, start that tweet with an `@username`. You're sending someone a public at message, but not actually replying to them. These posts were not included in the filtering with skip replies, although I'm not 100% sure they should be.

I do think these should be filterable, but maybe it should be a separate flag, since they are a little different in nature than an actual reply. Not sure. Either way, I didn't want 'em.